### PR TITLE
Correction to Migration

### DIFF
--- a/hordak/migrations/0035_account_currencies_json.py
+++ b/hordak/migrations/0035_account_currencies_json.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
             name="currencies_json",
             field=models.JSONField(
                 db_index=True,
-                default=hordak.models.core.default_currencies,
+                default=[],
             ),
         ),
         migrations.RunPython(copy_currencies_data),


### PR DESCRIPTION
```
TypeError: Object of type function is not JSON serializable
```

I tested this branch against our setup and got this error during the migration. Really weird since in the [next migration file it](https://github.com/adamcharnock/django-hordak/pull/91/files#diff-3daad17ebd3786832d356cc3307402d8528fb4aed074ce86b793873068725e4cR28) performs the alter back to the function, but that does not throw the error.